### PR TITLE
Replaced registerVar with the exported AddParam method. This method a…

### DIFF
--- a/common.go
+++ b/common.go
@@ -38,6 +38,17 @@ func ParamNames(r *http.Request) []string {
 	return names
 }
 
+// AddParam - Add a vestigo-style parameter to the request -- useful for middleware
+// Appends :name=value onto a blank request query string or appends &:name=value
+// onto a non-blank request query string
+func AddParam(r *http.Request, name, value string) {
+	if r.URL.RawQuery != "" {
+		r.URL.RawQuery += "&%3A" + name + "=" + value
+	} else {
+		r.URL.RawQuery += "%3A" + name + "=" + value
+	}
+}
+
 //validMethod - validate that the http method is valid.
 func validMethod(method string) bool {
 	var ok = false
@@ -48,13 +59,4 @@ func validMethod(method string) bool {
 		}
 	}
 	return ok
-}
-
-// registerVar - Put the URL Parameter into the request's RawQuery, very PAT like.
-func registerVar(r *http.Request, fmtpname string, pvalue string) {
-	if r.URL.RawQuery != "" {
-		r.URL.RawQuery += "&" + fmtpname + pvalue
-	} else {
-		r.URL.RawQuery += fmtpname + pvalue
-	}
 }

--- a/router.go
+++ b/router.go
@@ -265,7 +265,7 @@ func (r *Router) Find(req *http.Request) (h http.HandlerFunc) {
 			for ; i < l && search[i] != '/'; i++ {
 			}
 
-			registerVar(req, cn.fmtpnames[n], search[:i])
+			AddParam(req, cn.pnames[n], search[:i])
 			n++
 			search = search[i:]
 			continue
@@ -277,7 +277,7 @@ func (r *Router) Find(req *http.Request) (h http.HandlerFunc) {
 		c = cn.findChildWithType(mtype)
 		if c != nil {
 			cn = c
-			registerVar(req, cn.fmtpnames[len(cn.pnames)-1], search)
+			AddParam(req, cn.pnames[len(cn.pnames)-1], search)
 			search = "" // End search
 			continue
 		}

--- a/tree.go
+++ b/tree.go
@@ -7,14 +7,14 @@ package vestigo
 
 // node - a node structure for nodes within the tree
 type node struct {
-	typ       ntype
-	label     byte
-	prefix    string
-	parent    *node
-	children  children
-	resource  *resource
-	pnames    []string
-	fmtpnames []string
+	typ      ntype
+	label    byte
+	prefix   string
+	parent   *node
+	children children
+	resource *resource
+	pnames   []string
+	//fmtpnames []string
 }
 
 // newNode - create a new router tree node
@@ -28,9 +28,6 @@ func newNode(t ntype, pre string, p *node, c children, h *resource, pnames []str
 		// create a resource method to handler map for this node
 		resource: h,
 		pnames:   pnames,
-	}
-	for _, v := range pnames {
-		n.fmtpnames = append(n.fmtpnames, "%3A"+v+"=")
 	}
 	return n
 }


### PR DESCRIPTION
Replaced registerVar with the exported AddParam method. This method also freed up the need for fmtpnames on nodes.

I ran into an issue where I was writing middleware with your router and wanted a convenient way to add params to the request in the same format as the router to keep things consistent. So I looked through the code and developed my own method for adding params similar to the way you do it. I figured I'd see if you wanted to add it to the codebase as a valid exported method.