### PR TITLE
fix for https://github.com/husobee/vestigo/issues/28 

### DIFF
--- a/common.go
+++ b/common.go
@@ -25,7 +25,7 @@ var AllowTrace = false
 
 // Param - Get a url parameter by name
 func Param(r *http.Request, name string) string {
-	return r.FormValue(":" + name)
+	return r.URL.Query().Get(":" + name)
 }
 
 // ParamNames - Get a url parameter name list


### PR DESCRIPTION
no longer using r.FormValue to get params