### PR TITLE
potential fix for issue 49, seek out sibling wildcard, not just pname

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,15 @@ func Profile(w http.ResponseWriter, r *http.Request) {
 
 ```
 
+Note on wildcards: if you want to get the actual path matched by the wildcard
+you can perform `vestigo.Param("_name")` to get the matched path, example below:
 
+```
+    router.Get("/*", func(w http.ResponseWriter, r *http.Request) {
+        fmt.Println(vestigo.Param("_name"))
+    }
+
+```
 
 ## Licensing
 

--- a/router.go
+++ b/router.go
@@ -251,6 +251,17 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 		if l == pl {
 			// Continue search
 			search = search[l:]
+
+			if search == "" && cn != nil && cn.parent != nil && cn.resource.allowedMethods == "" {
+				for cn.parent != nil {
+					search = cn.prefix + search
+					cn = cn.parent
+					if sib := cn.findChildWithLabel('*'); sib != nil {
+						goto MatchAny
+					}
+				}
+			}
+
 		} else {
 			// last ditch effort to match on wildcard (issue #8)
 			if cn != nil && cn.parent != nil {
@@ -314,6 +325,7 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 		// Match-any node
 	MatchAny:
 		//		c = cn.getChild()
+
 		c = cn.findChildWithType(mtype)
 		if c != nil {
 			cn = c
@@ -322,7 +334,7 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 			continue
 		}
 		// last ditch effort to match on wildcard (issue #8)
-		if cn != nil && cn != nil && cn.label != ':' {
+		if cn != nil && cn.label != ':' {
 			if cn.parent != nil {
 				if sib := cn.parent.findChildWithLabel(':'); sib != nil {
 					search = cn.prefix + search
@@ -332,6 +344,22 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 			}
 		}
 
+		// last ditch wildcard
+		found := false
+		for cn.parent != nil {
+			search = cn.prefix + search
+			cn = cn.parent
+			if sib := cn.findChildWithLabel('*'); sib != nil {
+				cn = sib
+				//search = ""
+				found = true
+				break
+			}
+		}
+
+		if found {
+			continue
+		}
 		// Not found
 		return
 	}

--- a/router.go
+++ b/router.go
@@ -253,12 +253,13 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 			search = search[l:]
 		} else {
 			// last ditch effort to match on wildcard (issue #8)
-			if cn != nil && cn != nil && cn.label != ':' {
-				if cn.parent != nil {
-					if sib := cn.parent.findChildWithLabel(':'); sib != nil {
-						cn = cn.parent
-						goto Param
-					}
+			if cn != nil && cn.parent != nil {
+				cn = cn.parent
+				if sib := cn.findChildWithLabel(':'); sib != nil {
+					goto Param
+				}
+				if sib := cn.findChildWithLabel('*'); sib != nil {
+					goto MatchAny
 				}
 			}
 

--- a/router_test.go
+++ b/router_test.go
@@ -342,27 +342,6 @@ func TestParamNames(t *testing.T) {
 	assert.Equal(t, foundLocation, true)
 }
 
-/*
-func TestRouterMatchAny(t *testing.T) {
-	r := NewRouter()
-	r.Add(GET, "/users/*", func(w http.ResponseWriter, r *http.Request) {})
-
-	req, _ := http.NewRequest("GET", "/users/", nil)
-
-	h, _ := r.Find(req)
-	if assert.NotNil(t, h) {
-		assert.Equal(t, "", c.P(0))
-	}
-
-	req2, _ := http.NewRequest("GET", "/users/1", nil)
-
-	h, _ = r.Find(req2)
-	if assert.NotNil(t, h) {
-		assert.Equal(t, "1", c.P(0))
-	}
-}
-*/
-
 func TestRouterMicroParam(t *testing.T) {
 	r := NewRouter()
 	r.Add("GET", "/:a/:b/:c", func(w http.ResponseWriter, r *http.Request) {})
@@ -556,7 +535,6 @@ func TestRouterParamNames(t *testing.T) {
 	req, _ = http.NewRequest("GET", "/users/1/files/1", nil)
 	w = httptest.NewRecorder()
 	h = r.Find(req)
-	r.root.printTree("", true)
 	if assert.NotNil(t, h) {
 		h(w, req)
 		assert.Equal(t, "1", Param(req, "uid"))
@@ -812,4 +790,22 @@ func TestMatchedURLTemplate(t *testing.T) {
 		templ := r.GetMatchedPathTemplate(req)
 		assert.Equal(t, templ, v)
 	}
+}
+
+func TestIssue49(t *testing.T) {
+
+	r := NewRouter()
+
+	r.Get("/greet/:name", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "Welcome %s\n", Param(r, "name"))
+	})
+	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "You opened %s\n", Param(r, "_name"))
+	})
+
+	req, _ := http.NewRequest("GET", "/g", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.True(t, strings.Contains(w.Body.String(), "You opened"))
+
 }

--- a/router_test.go
+++ b/router_test.go
@@ -792,7 +792,7 @@ func TestMatchedURLTemplate(t *testing.T) {
 	}
 }
 
-func TestIssue49(t *testing.T) {
+func TestIssue49a(t *testing.T) {
 
 	r := NewRouter()
 
@@ -807,5 +807,42 @@ func TestIssue49(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.True(t, strings.Contains(w.Body.String(), "You opened"))
+
+}
+
+func TestIssue49b(t *testing.T) {
+
+	r := NewRouter()
+
+	r.Get("/books/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "/books/\n")
+	})
+
+	r.Get("/books/:book", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "/books/%s\n", Param(r, "book"))
+	})
+
+	r.Get("/bookcase/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "/bookcase/\n")
+	})
+
+	r.HandleFunc("/*", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "wildcard!! %s\n", Param(r, "_name"))
+	})
+
+	req, _ := http.NewRequest("GET", "/books", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.True(t, strings.Contains(w.Body.String(), "wildcard!!"))
+
+	req, _ = http.NewRequest("GET", "/bookk", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.True(t, strings.Contains(w.Body.String(), "wildcard!!"))
+
+	req, _ = http.NewRequest("GET", "/book", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.True(t, strings.Contains(w.Body.String(), "wildcard!!"))
 
 }


### PR DESCRIPTION
potential fix for https://github.com/husobee/vestigo/issues/49 the issue seems to be that we were only checking siblings for wildcards in the event we didn't have an exact match, and not checking for wildcard nodes.