### PR TITLE
Fix for ParamNames

### DIFF
--- a/common.go
+++ b/common.go
@@ -32,8 +32,19 @@ func Param(r *http.Request, name string) string {
 	return r.URL.Query().Get(":" + name)
 }
 
-// ParamNames - Get a url parameter name list
+// ParamNames - Get a url parameter name list with the leading :
 func ParamNames(r *http.Request) []string {
+	var names []string
+	for k := range r.URL.Query() {
+		if strings.HasPrefix(k, ":") {
+			names = append(names, k)
+		}
+	}
+	return names
+}
+
+// TrimmedParamNames - Get a url parameter name list without the leading :
+func TrimmedParamNames(r *http.Request) []string {
 	var names []string
 	for k := range r.URL.Query() {
 		if strings.HasPrefix(k, ":") {

--- a/common.go
+++ b/common.go
@@ -37,7 +37,7 @@ func ParamNames(r *http.Request) []string {
 	var names []string
 	for k := range r.URL.Query() {
 		if strings.HasPrefix(k, ":") {
-			names = append(names, k)
+			names = append(names, strings.TrimPrefix(k, ":"))
 		}
 	}
 	return names

--- a/common_test.go
+++ b/common_test.go
@@ -1,0 +1,50 @@
+package vestigo
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTrimmedParamNames(t *testing.T) {
+	router := NewRouter()
+
+	// Wildcard should be _name
+	router.Get("/*", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("/*")
+		assert.Equal(t, []string([]string{"_name"}), TrimmedParamNames(r), "Should be _name")
+	})
+
+	// Some random name should be b
+	router.Get("/a/:b", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("/a/:b")
+		assert.Equal(t, []string([]string{"b"}), TrimmedParamNames(r), "Should be b")
+	})
+
+	// Some random name
+	router.Get("/:a", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("/:a")
+		assert.Equal(t, []string([]string{"a"}), TrimmedParamNames(r), "Should be a")
+	})
+
+	// Multiple parameters random name
+	router.Get("/a/:b/c/:d", func(w http.ResponseWriter, r *http.Request) {
+		log.Println("/a/:b/c/:d")
+		assert.Equal(t, []string([]string{"b", "d"}), TrimmedParamNames(r), "Should be [b, c]")
+	})
+
+	rec := httptest.NewRecorder()
+
+	req1, _ := http.NewRequest("GET", "/a/", nil)
+	req4, _ := http.NewRequest("GET", "/a", nil)
+	req2, _ := http.NewRequest("GET", "/a/b", nil)
+	req3, _ := http.NewRequest("GET", "/a/b/c/d", nil)
+
+	router.ServeHTTP(rec, req1)
+	router.ServeHTTP(rec, req2)
+	router.ServeHTTP(rec, req3)
+	router.ServeHTTP(rec, req4)
+}


### PR DESCRIPTION
I noticed that the function ParamNames gets all param names, but doesn't remove the : at the beginning of a parameter. If one tries to use the names returned by ParamNames, there will be additional :
I added a simple TrimPrefix to solve this.