### PR TITLE
issue 64

### DIFF
--- a/router.go
+++ b/router.go
@@ -188,6 +188,7 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 
 	// Search order static > param > match-any
 	for {
+
 		if search == "" {
 			if cn.resource != nil {
 				// Found route, check if method is applicable
@@ -317,7 +318,7 @@ func (r *Router) find(req *http.Request) (prefix string, h http.HandlerFunc) {
 		// last ditch effort to match on wildcard (issue #8)
 		var tmpsearch = search
 		for {
-			if cn != nil && cn.parent != nil {
+			if cn != nil && cn.parent != nil && cn.prefix != ":" {
 				tmpsearch = cn.prefix + tmpsearch
 				cn = cn.parent
 				if cn.prefix == "/" {

--- a/router_test.go
+++ b/router_test.go
@@ -1072,3 +1072,23 @@ func TestRouter_SearchSmallerThanPrefix(t *testing.T) {
 	assert.Equal(t, w.Body.String(), "custom not found")
 
 }
+
+func TestRouter_Issue64(t *testing.T) {
+	r := NewRouter()
+
+	r.Get("/foo", func(w http.ResponseWriter, r *http.Request) { fmt.Fprintln(w, "foo") })
+	r.Get("/:lang/foo", func(w http.ResponseWriter, r *http.Request) { fmt.Fprintln(w, "foo") })
+
+	// OK
+	normalRequest, _ := http.NewRequest("GET", "/hello/world", nil)
+
+	_, h := r.find(normalRequest)
+
+	w := httptest.NewRecorder()
+	if assert.NotNil(t, h) {
+		h(w, normalRequest)
+	}
+
+	assert.Equal(t, w.Body.String(), "custom not found")
+
+}


### PR DESCRIPTION
correcting infinte loop issue when backtracking over url param nodes, found in issue 64.  An artifact of the issue 63 fix.