### PR TITLE
HTTP HEAD: Assume 200 status if none is written

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -37,8 +37,9 @@ func CustomMethodNotAllowedHandlerFunc(f MethodNotAllowedHandlerFunc) {
 
 // headResponseWriter - implementation of http.ResponseWriter for headHandler
 type headResponseWriter struct {
-	HeaderMap http.Header
-	Code      int
+	HeaderMap   http.Header
+	Code        int
+	wroteHeader bool
 }
 
 func (hrw *headResponseWriter) Header() http.Header {
@@ -49,10 +50,17 @@ func (hrw *headResponseWriter) Header() http.Header {
 }
 
 func (hrw *headResponseWriter) Write([]byte) (int, error) {
+	// Mirror http.ResponseWriter: "If WriteHeader has not yet been called,
+	// Write calls WriteHeader(http.StatusOK) before writing the data."
+	if !hrw.wroteHeader {
+		hrw.WriteHeader(http.StatusOK)
+	}
+
 	return 0, nil
 }
 
 func (hrw *headResponseWriter) WriteHeader(status int) {
+	hrw.wroteHeader = true
 	hrw.Code = status
 }
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -147,6 +147,25 @@ func TestHeadNilFunc(t *testing.T) {
 	}
 }
 
+func TestHeadNoWriteHeader(t *testing.T) {
+	router := NewRouter()
+	path := "/test"
+	router.Get(path, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-TestHeader", "true")
+		w.Write([]byte("some return body"))
+	})
+
+	w := httptest.NewRecorder()
+	r, err := http.NewRequest("HEAD", path, nil)
+	if err != nil {
+		t.Errorf("Failed to create a new request, method: %s, path: %s", "HEAD", path)
+	}
+	router.ServeHTTP(w, r)
+	if w.Code != 200 || w.Body.String() != "" || w.Header().Get("X-TestHeader") != "true" {
+		t.Errorf("Invalid HEAD response, method: %s, path: %s, code: %d, body: %s", "HEAD", path, w.Code, w.Body.String())
+	}
+}
+
 func TestNotFound(t *testing.T) {
 	router := NewRouter()
 	path := "/test"


### PR DESCRIPTION
We're seeing a panic for some requests that don't explicitly call WriteHeader, relying on the standard library calling WriteHeader(http.StatusOK) if we don't choose a status explicitly.

This PR changes headResponseWriter to have the same Write([]byte) behavior.

A sample panic:

    2018/05/14 14:28:49 http: panic serving 127.0.0.1:51138: invalid WriteHeader code 0
    goroutine 5 [running]:
    net/http.(*conn).serve.func1(0xc4201720a0)
            $GOROOT/src/net/http/server.go:1726 +0xd0
    panic(0x64a780, 0xc420096d60)
            $GOROOT/src/runtime/panic.go:502 +0x229
    net/http.checkWriteHeaderCode(0x0)
           $GOROOT/src/net/http/server.go:1070 +0xf3
    net/http.(*response).WriteHeader(0xc42017a0e0, 0x0)
            $GOROOT/src/net/http/server.go:1083 +0x67
    github.com/husobee/vestigo.glob..func2.1(0x6e6b60, 0xc42017a0e0, 0xc42013e300)
            github.com/husobee/vestigo/handlers.go:84 +0x1de
    github.com/husobee/vestigo.glob..func6.1(0x6e6b60, 0xc42017a0e0, 0xc42013e300)
            github.com/husobee/vestigo/handlers.go:152 +0x273
    github.com/husobee/vestigo.(*Router).ServeHTTP(0xc420096a20, 0x6e6b60, 0xc42017a0e0, 0xc42013e300)
            github.com/husobee/vestigo/router.go:67 +0x5c
    net/http.serverHandler.ServeHTTP(0xc42009cea0, 0x6e6b60, 0xc42017a0e0, 0xc42013e300)
           $GOROOT/src/net/http/server.go:2694 +0xbc
    net/http.(*conn).serve(0xc4201720a0, 0x6e6d20, 0xc4200aa4c0)
            $GOROOT/src/net/http/server.go:1830 +0x651
    created by net/http.(*Server).Serve
            $GOROOT/src/net/http/server.go:2795 +0x27b
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x61d18e]
